### PR TITLE
Makefile: Force symlink creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ install:
 	install -m 00644 $(top_srcdir)/tools/kirk/libkirk/*.py $(BASE_DIR)/libkirk
 	install -m 00775 $(top_srcdir)/tools/kirk/kirk $(BASE_DIR)/kirk
 
-	ln -s $(BASE_DIR)/runltp-ng $(BASE_DIR)/kirk
+	ln -sf $(BASE_DIR)/runltp-ng $(BASE_DIR)/kirk
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk


### PR DESCRIPTION
This fixes failure when repeatedly run make install:

ln -s /opt/ltp/runltp-ng /opt/ltp/kirk
ln: failed to create symbolic link '/opt/ltp/kirk': File exists make: *** [Makefile:16: install] Error 1

Fixes: 666a2bd ("Symlink kirk with runltp-ng in LTP installation")