### PR TITLE
Makefile: Make symlink relative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ install:
 	install -m 00644 $(top_srcdir)/tools/kirk/libkirk/*.py $(BASE_DIR)/libkirk
 	install -m 00775 $(top_srcdir)/tools/kirk/kirk $(BASE_DIR)/kirk
 
-	ln -sf $(BASE_DIR)/kirk $(BASE_DIR)/runltp-ng
+	ln -sf kirk runltp-ng
 
 include $(top_srcdir)/include/mk/generic_leaf_target.mk


### PR DESCRIPTION
Using full path creates problems with rpm packaging:

```
ERROR: Link /opt/ltp/runltp-ng ->
/home/abuild/rpmbuild/BUILDROOT/ltp-20230929.48a150bf-1573.1.x86_64/opt/ltp/kirk points inside build root
```

Fixes: 666a2bd ("Symlink kirk with runltp-ng in LTP installation")
Fixes: 7e397fe ("Fix 666a2bd8dbf583732ed415abf1bae39bd8791061")