### PR TITLE
libkirk/host.py: Redirect stderr to stdout

### DIFF
--- a/libkirk/host.py
+++ b/libkirk/host.py
@@ -144,7 +144,7 @@ class HostSUT(SUT):
         try:
             kwargs = {
                 "stdout": asyncio.subprocess.PIPE,
-                "stderr": asyncio.subprocess.PIPE,
+                "stderr": asyncio.subprocess.STDOUT,
                 "cwd": cwd,
                 "preexec_fn": os.setsid
             }

--- a/libkirk/sut.py
+++ b/libkirk/sut.py
@@ -253,7 +253,13 @@ class SUT(Plugin):
             stdout = ret["stdout"].rstrip()
 
             tainted_num = len(TAINED_MSG)
-            code = int(stdout.rstrip())
+            code = stdout.rstrip()
+
+            # output is likely message in stderr
+            if not code.isdigit():
+                raise SUTError(code)
+
+            code = int(code)
             bits = format(code, f"0{tainted_num}b")[::-1]
 
             messages = []


### PR DESCRIPTION
This fixes a problem with missing output on LTP new C API and new shell API, which both print tst_res() and tst_brk() messages to stderr (unlike the old APIs which print to stdout).

```
$ /root/kirk.git/kirk -r smoketest -v
...
===== access01 =====
command: access01
Tained kernel: unsigned module was loaded
tst_test.c:1690: TINFO: LTP version: 20230929-89-g446d82e5b
tst_test.c:1574: TINFO: Timeout per run is 0h 05m 24s
access01.c:245: TPASS: access(accessfile_rwx, F_OK) as root passed
access01.c:245: TPASS: access(accessfile_rwx, F_OK) as nobody passed
...
===== ping602 =====
command: ping02.sh -6
Tained kernel: unsigned module was loaded
ping02 1 TINFO: Running: ping02.sh -6
ping02 1 TINFO: IPv6 disabled on lhost via kernel command line or not compiled in
ping02 1 TINFO: initialize 'lhost' 'ltp_ns_veth2' interface
```
Without this patch TINFO messages would be missing in the output and in the logs (debug.log, results.json).

Merging stdout and stderr together can lead to problem of unexpected
output (message from stderr instead of expected number in
get_tainted_info()):

```
$ mkdir /tmp/foo; cd /tmp/foo; rm -rf /tmp/foo; cd .
cd: error retrieving current directory: getcwd: cannot access parent
directories: No such file or directory
$ /root/kirk.git/kirk -r smoketest -v
...
  File "/root/kirk.git/libkirk/scheduler.py", line 231, in _run_test
    tainted_code1, _ = await self._get_tainted_status()
  File "/root/kirk.git/libkirk/scheduler.py", line 150, in _get_tainted_status
    code, messages = await self._sut.get_tainted_info()
  File "/root/kirk.git/libkirk/sut.py", line 256, in get_tainted_info
    code = int(stdout.rstrip())
ValueError: invalid literal for int() with base 10: 'shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory\n8192'
```

Therefore add check for it:
```
$ /root/kirk.git/kirk -r smoketest -v
Kernel Version: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
Linux 6.3.1-0.g944cb55-default #1 SMP PREEMPT_DYNAMIC Thu May 11 07:12:30 UTC 2023 (944cb55)
CPU: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
x86_64
Machine Architecture: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
x86_64
RAM: 2010696 kB
Swap memory: 2098152 kB
Distro: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
opensuse-tumbleweed
Distro Version: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
20230502

Error: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
8192
```

Fixes: #8