### PR TITLE
Kselftests fix test name

### DIFF
--- a/libkirk/kselftests.py
+++ b/libkirk/kselftests.py
@@ -71,7 +71,7 @@ class KselftestFramework(Framework):
                 continue
 
             tests_obj.append(Test(
-                name=myname,
+                name=myname.group(),
                 cmd=os.path.join(cgroup_dir, name),
                 cwd=cgroup_dir,
                 parallelizable=False))


### PR DESCRIPTION
This fix a problem with c95c16b52d5a25c528cd93ba552d79cbb731d6d1 which is passing the wrong object to the UI.