### PR TITLE
Wait for SSH command to complete after execution

### DIFF
--- a/libkirk/kselftests.py
+++ b/libkirk/kselftests.py
@@ -71,7 +71,7 @@ class KselftestFramework(Framework):
                 continue
 
             tests_obj.append(Test(
-                name=myname,
+                name=myname.group(),
                 cmd=os.path.join(cgroup_dir, name),
                 cwd=cgroup_dir,
                 parallelizable=False))

--- a/libkirk/scheduler.py
+++ b/libkirk/scheduler.py
@@ -23,7 +23,7 @@ from libkirk.results import TestResults
 from libkirk.results import SuiteResults
 
 
-class KernelTainedError(KirkException):
+class KernelTaintedError(KirkException):
     """
     Raised when kernel is tainted.
     """
@@ -98,7 +98,7 @@ class TestScheduler(Scheduler):
     STATUS_OK = 0
     TEST_TIMEOUT = 1
     KERNEL_PANIC = 2
-    KERNEL_TAINED = 3
+    KERNEL_TAINTED = 3
     KERNEL_TIMEOUT = 4
 
     def __init__(self, **kwargs: dict) -> None:
@@ -228,7 +228,7 @@ class TestScheduler(Scheduler):
                         tainted_msg2)
 
                     tainted_msg = tainted_msg2
-                    status = self.KERNEL_TAINED
+                    status = self.KERNEL_TAINTED
             except libkirk.sut.KernelPanicError:
                 exec_time = time.time() - start_t
 
@@ -253,7 +253,7 @@ class TestScheduler(Scheduler):
                     status = self.KERNEL_TIMEOUT
 
             # create test results and save it
-            if status not in [self.STATUS_OK, self.KERNEL_TAINED]:
+            if status not in [self.STATUS_OK, self.KERNEL_TAINTED]:
                 test_data = {
                     "name": test.name,
                     "command": test.full_command,
@@ -272,9 +272,9 @@ class TestScheduler(Scheduler):
             self._results.append(results)
 
             # raise kernel errors at the end so we can collect test results
-            if status == self.KERNEL_TAINED:
+            if status == self.KERNEL_TAINTED:
                 await libkirk.events.fire("kernel_tainted", tainted_msg)
-                raise KernelTainedError()
+                raise KernelTaintedError()
 
             if status == self.KERNEL_PANIC:
                 await libkirk.events.fire("kernel_panic")
@@ -508,7 +508,7 @@ class SuiteScheduler(Scheduler):
 
                     timed_out = True
                 except (KernelPanicError,
-                        KernelTainedError,
+                        KernelTaintedError,
                         KernelTimeoutError):
                     # once we catch a kernel error, restart the SUT
                     await self._restart_sut()

--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -57,7 +57,7 @@ class SSHSUT(SUT):
             "password": "root password",
             "timeout": "connection timeout in seconds (default: 10)",
             "key_file": "private key location",
-            "reset_command": "command to reset the remote SUT",
+            "reset_cmd": "command to reset the remote SUT",
             "sudo": "use sudo to access to root shell (default: 0)",
         }
 

--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -269,8 +269,7 @@ class SSHSUT(SUT):
                 if proc:
                     self._procs.remove(proc)
 
-                    if proc.returncode is None:
-                        proc.kill()
+                    await proc.wait()
 
                     ret = {
                         "command": command,

--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -55,7 +55,6 @@ class SSHSUT(SUT):
             "port": "TCP port of the service (default: 22)",
             "user": "name of the user (default: root)",
             "password": "root password",
-            "timeout": "connection timeout in seconds (default: 10)",
             "key_file": "private key location",
             "reset_cmd": "command to reset the remote SUT",
             "sudo": "use sudo to access to root shell (default: 0)",

--- a/libkirk/sut.py
+++ b/libkirk/sut.py
@@ -35,7 +35,7 @@ class IOBuffer:
         raise NotImplementedError()
 
 
-TAINED_MSG = [
+TAINTED_MSG = [
     "proprietary module was loaded",
     "module was force loaded",
     "kernel running on an out of specification system",
@@ -252,7 +252,7 @@ class SUT(Plugin):
 
             stdout = ret["stdout"].rstrip()
 
-            tainted_num = len(TAINED_MSG)
+            tainted_num = len(TAINTED_MSG)
             code = stdout.rstrip()
 
             # output is likely message in stderr
@@ -265,7 +265,7 @@ class SUT(Plugin):
             messages = []
             for i in range(0, tainted_num):
                 if bits[i] == "1":
-                    msg = TAINED_MSG[i]
+                    msg = TAINTED_MSG[i]
                     messages.append(msg)
 
             if self._tainted_status.qsize() > 0:

--- a/libkirk/tests/test_scheduler.py
+++ b/libkirk/tests/test_scheduler.py
@@ -4,13 +4,13 @@ Unittests for runner module.
 import re
 import asyncio
 import pytest
-from libkirk.sut import TAINED_MSG
+from libkirk.sut import TAINTED_MSG
 from libkirk.data import Test
 from libkirk.data import Suite
 from libkirk.host import HostSUT
 from libkirk.scheduler import TestScheduler
 from libkirk.scheduler import SuiteScheduler
-from libkirk.scheduler import KernelTainedError
+from libkirk.scheduler import KernelTaintedError
 from libkirk.scheduler import KernelTimeoutError
 from libkirk.scheduler import KernelPanicError
 
@@ -193,7 +193,7 @@ class TestTestScheduler:
                 parallelizable=True,
             ))
 
-        with pytest.raises(KernelTainedError):
+        with pytest.raises(KernelTaintedError):
             await runner.schedule(tests)
 
     @pytest.mark.parametrize("workers", [1, 10])
@@ -368,7 +368,7 @@ class TestSuiteScheduler:
         index = 0
         value = 0
 
-        for msg in TAINED_MSG:
+        for msg in TAINTED_MSG:
             tainted.append((value, [msg]))
             value = pow(2, index)
             index += 1

--- a/libkirk/tests/test_ssh.py
+++ b/libkirk/tests/test_ssh.py
@@ -56,9 +56,9 @@ class _TestSSHSUT(_TestSUT):
     Test SSHSUT implementation using username/password.
     """
 
-    async def test_reset_command(self, config):
+    async def test_reset_cmd(self, config):
         """
-        Test reset_command option.
+        Test reset_cmd option.
         """
         kwargs = dict(reset_cmd="echo ciao")
         kwargs.update(config)

--- a/libkirk/ui.py
+++ b/libkirk/ui.py
@@ -266,7 +266,7 @@ class VerboseUserInterface(ConsoleUserInterface):
         self._print(data, end='')
 
     async def kernel_tainted(self, message: str) -> None:
-        self._print(f"Tained kernel: {message}", color=self.YELLOW)
+        self._print(f"Tainted kernel: {message}", color=self.YELLOW)
 
     async def test_timed_out(self, _: Test, timeout: int) -> None:
         self._timed_out = True


### PR DESCRIPTION
This patch resolves a problem that started to show up when fast commands, such as 'cat', were executed on target. The original code was killing the command once we faced a return_value == None. This is obviously wrong and it probably comes from multiple SSH module implementations.

The right thing to do is to wait for the process completion, once we finish to read stdout. In this way, return_value will be != None and we can process fast commands execution.