### PR TITLE
Fix SSH execution not redirecting output properly

### DIFF
--- a/libkirk/ltp.py
+++ b/libkirk/ltp.py
@@ -362,7 +362,9 @@ class LTPFramework(Framework):
                 elif not error:
                     failed = 1
 
-        if retcode in (2, -1):
+        if retcode == 0:
+            status = ResultStatus.PASS
+        elif retcode in (2, -1):
             status = ResultStatus.BROK
         elif retcode == 4:
             status = ResultStatus.WARN


### PR DESCRIPTION
This patch aims to save commands stdout/stderr once they are executed inside the SSH channel. The whole implementation has been changed, in order to customize the current SSH session object and to store both stdout and stderr messages inside it, as well as checking for Kernel Panic triggered by the command. In this way, the whole SSH implementation should be also more stable.

Also, SSH tests have been improved by adding more tests, in order to check stderr acquisition and long stdout text messages.