### PR TITLE
SSH module is not showing live stdout/stderr

### DIFF
--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -38,7 +38,7 @@ try:
             self._output.append(data)
 
             if self._iobuffer:
-                self._iobuffer.write(data)
+                asyncio.ensure_future(self._iobuffer.write(data))
 
             if "Kernel panic" in data:
                 self._panic = True


### PR DESCRIPTION
The IOBuffer object that is meant to show realtime messages coming from the SSH commands was not passed to the event loop. Instead, it was called as a normal callback. asyncio.ensure_future() is now used to ensure that task will run.