### PR TITLE
Add pypi package

### DIFF
--- a/libkirk/__init__.py
+++ b/libkirk/__init__.py
@@ -13,7 +13,7 @@ from libkirk.events import EventsHandler
 
 
 # Kirk version
-VERSION = '1.1'
+__version__ = '1.1'
 
 
 class KirkException(Exception):

--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -350,8 +350,8 @@ def run(cmd_args: list = None) -> None:
     parser.add_argument(
         "--version",
         "-V",
-        action="store_true",
-        help="Print current version")
+        action="version",
+        version=f"%(prog)s, {libkirk.VERSION}")
 
     # user interface arguments
     parser.add_argument(
@@ -452,10 +452,6 @@ def run(cmd_args: list = None) -> None:
 
     # parse comand line
     args = parser.parse_args(cmd_args)
-
-    if args.version:
-        print(f"kirk {libkirk.VERSION}")
-        parser.exit(RC_OK)
 
     if args.sut and "help" in args.sut:
         print(args.sut["help"])

--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -14,7 +14,7 @@ import libkirk.sut
 import libkirk.data
 import libkirk.events
 import libkirk.plugin
-from libkirk import KirkException
+from libkirk import KirkException, __version__
 from libkirk.sut import SUT
 from libkirk.sut import SUTError
 from libkirk.framework import Framework
@@ -351,7 +351,7 @@ def run(cmd_args: list = None) -> None:
         "--version",
         "-V",
         action="version",
-        version=f"%(prog)s, {libkirk.VERSION}")
+        version=f"%(prog)s, {__version__}")
 
     # user interface arguments
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "kirk"
+authors = [{name = "Andrea Cervesato", email = "andrea.cervesato@suse.com"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = ["License :: OSI Approved :: GNU Lesser General Public License v2 (GPLv2)"]
+requires-python = ">=3.6"
+dynamic = ["version", "description"]
+
+[project.optional-dependencies]
+all = [
+    "asyncssh",
+    "msgpack",
+]
+
+[tool.flit.module]
+name = "libkirk"
+
+[project.scripts]
+kirk = "libkirk.main:run"
+
+[project.urls]
+Source = "https://github.com/linux-test-project/kirk.git"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='kirk',
-    version=libkirk.VERSION,
+    version=libkirk.__version__,
     description='All-in-one Linux Testing Framework',
     author='Andrea Cervesato',
     author_email='andrea.cervesato@mailbox.org',


### PR DESCRIPTION
@roxell Feel free to correct me.

@acerv @metan-ucw FYI Anders would appreciate have kirk published via pypi package, that's why this effort.

We have setuptools, but pypi package would allow to run 'pip install kirk' (that
would allow to avoid git dependency).

While I would not be against, sooner or later LTP users will need also ltx, thus pip
is not enough. But still having kirk available for any distro via pip will be useful for kselftests and io_uring.

Also, we could enable Debian package (and other distros) in OBS projects:

https://build.opensuse.org/package/show/benchmark:ltp:devel/ltx
https://build.opensuse.org/package/show/benchmark:ltp:devel/kirk