### PR TITLE
Fix kirk version

### DIFF
--- a/libkirk/__init__.py
+++ b/libkirk/__init__.py
@@ -13,7 +13,7 @@ from libkirk.events import EventsHandler
 
 
 # Kirk version
-VERSION = '1.1'
+__version__ = '1.1'
 
 
 class KirkException(Exception):

--- a/libkirk/__init__.py
+++ b/libkirk/__init__.py
@@ -13,7 +13,7 @@ from libkirk.events import EventsHandler
 
 
 # Kirk version
-__version__ = '1.1'
+__version__ = '1.3'
 
 
 class KirkException(Exception):

--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -350,8 +350,8 @@ def run(cmd_args: list = None) -> None:
     parser.add_argument(
         "--version",
         "-V",
-        action="store_true",
-        help="Print current version")
+        action="version",
+        version=f"%(prog)s, {libkirk.VERSION}")
 
     # user interface arguments
     parser.add_argument(
@@ -452,10 +452,6 @@ def run(cmd_args: list = None) -> None:
 
     # parse comand line
     args = parser.parse_args(cmd_args)
-
-    if args.version:
-        print(f"kirk {libkirk.VERSION}")
-        parser.exit(RC_OK)
 
     if args.sut and "help" in args.sut:
         print(args.sut["help"])

--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -14,7 +14,7 @@ import libkirk.sut
 import libkirk.data
 import libkirk.events
 import libkirk.plugin
-from libkirk import KirkException
+from libkirk import KirkException, __version__
 from libkirk.sut import SUT
 from libkirk.sut import SUTError
 from libkirk.framework import Framework
@@ -351,7 +351,7 @@ def run(cmd_args: list = None) -> None:
         "--version",
         "-V",
         action="version",
-        version=f"%(prog)s, {libkirk.VERSION}")
+        version=f"%(prog)s, {__version__}")
 
     # user interface arguments
     parser.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='kirk',
-    version=libkirk.VERSION,
+    version=libkirk.__version__,
     description='All-in-one Linux Testing Framework',
     author='Andrea Cervesato',
     author_email='andrea.cervesato@mailbox.org',


### PR DESCRIPTION
Declare kirk version as `__version__` and handle `--version` option in a better way.
This patch also introduce the right kirk version that was not updated yet.

Reviewed-by: Petr Vorel <pvorel@suse.cz>
Reviewed-by: Andrea Cervesato <andrea.cervesato@suse.com>