### PR TITLE
libkirk/events: register the event handler for suite_timeout

### DIFF
--- a/libkirk/ui.py
+++ b/libkirk/ui.py
@@ -46,6 +46,7 @@ class ConsoleUserInterface:
         libkirk.events.register("run_cmd_stop", self.run_cmd_stop)
         libkirk.events.register("suite_started", self.suite_started)
         libkirk.events.register("suite_completed", self.suite_completed)
+        libkirk.events.register("suite_timeout", self.suite_timeout)
         libkirk.events.register("session_warning", self.session_warning)
         libkirk.events.register("session_error", self.session_error)
         libkirk.events.register("internal_error", self.internal_error)


### PR DESCRIPTION
In our testing, we find when suite timeout happened, nothing is printed. and it confuses us that many tests are skipped but no hint in the log. We find the handler is there but not registered, so add it there.

With the line added, we'll have the log like below when suite timeout happened:

Suite 'syscalls' timed out after 3600 seconds.