### PR TITLE
Execute sessions as long as runtime option requires

### DIFF
--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -363,6 +363,7 @@ def _start_session(
                 suite_iterate=args.suite_iterate,
                 skip_tests=skip_tests,
                 randomize=args.randomize,
+                runtime=args.runtime,
             )
         except asyncio.CancelledError:
             await session.stop()
@@ -501,6 +502,12 @@ def run(cmd_args: list = None) -> None:
         "-x",
         action="store_true",
         help="Force parallelization execution of all tests")
+    parser.add_argument(
+        "--runtime",
+        "-u",
+        type=_time_config,
+        default="0",
+        help="Set for how long we want to run the session in seconds")
 
     # session arguments
     parser.add_argument(

--- a/libkirk/scheduler.py
+++ b/libkirk/scheduler.py
@@ -48,6 +48,13 @@ class Scheduler:
         """
         raise NotImplementedError()
 
+    @property
+    def stopped(self) -> bool:
+        """
+        Returns True when scheduler has been stopped.
+        """
+        raise NotImplementedError()
+
     async def stop(self) -> None:
         """
         Stop all running jobs.
@@ -122,6 +129,7 @@ class TestScheduler(Scheduler):
         self._lock = asyncio.Lock()
         self._results = []
         self._stop = False
+        self._stopped = False
         self._tasks = []
 
         if not self._sut:
@@ -163,6 +171,10 @@ class TestScheduler(Scheduler):
     def results(self) -> list:
         return self._results
 
+    @property
+    def stopped(self) -> bool:
+        return self._stopped
+
     async def stop(self) -> None:
         if not self._tasks:
             return
@@ -182,6 +194,7 @@ class TestScheduler(Scheduler):
                 pass
         finally:
             self._stop = False
+            self._stopped = True
 
         self._logger.info("Tests execution has stopped")
 
@@ -401,6 +414,7 @@ class SuiteScheduler(Scheduler):
         self._suite_timeout = max(kwargs.get("suite_timeout", 3600.0), 0.0)
         self._results = []
         self._stop = False
+        self._stopped = False
         self._lock = asyncio.Lock()
 
         if not self._sut:
@@ -423,6 +437,10 @@ class SuiteScheduler(Scheduler):
     def results(self) -> list:
         return self._results
 
+    @property
+    def stopped(self) -> bool:
+        return self._stopped
+
     async def stop(self) -> None:
         if not self._lock.locked():
             return
@@ -437,6 +455,7 @@ class SuiteScheduler(Scheduler):
                 pass
         finally:
             self._stop = False
+            self._stopped = True
 
         self._logger.info("Suites execution has stopped")
 

--- a/libkirk/tests/test_main.py
+++ b/libkirk/tests/test_main.py
@@ -4,7 +4,6 @@ Unittests for main module.
 import os
 import sys
 import pwd
-import time
 import json
 import pytest
 import libkirk.main
@@ -22,7 +21,7 @@ class TestMain:
         """
         libkirk.main.LOADED_FRAMEWORK.append(dummy_framework)
 
-    def read_report(self, temp, tests_num) -> dict:
+    def read_report(self, temp) -> dict:
         """
         Check if report file contains the given number of tests.
         """
@@ -32,10 +31,8 @@ class TestMain:
 
         # read report and check if all suite's tests have been executed
         report_d = None
-        with open(report, 'r') as report_f:
+        with open(report, 'r', encoding="utf-8") as report_f:
             report_d = json.loads(report_f.read())
-
-        assert len(report_d["results"]) == tests_num
 
         return report_d
 
@@ -100,7 +97,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 2)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 2
 
     def test_run_suite_timeout(self, tmpdir):
         """
@@ -119,8 +117,10 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        report_d = self.read_report(temp, 2)
-        for param in report_d["results"]:
+        report = self.read_report(temp)
+        assert len(report["results"]) == 2
+
+        for param in report["results"]:
             assert param["test"]["passed"] == 0
             assert param["test"]["failed"] == 0
             assert param["test"]["broken"] == 0
@@ -186,7 +186,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 2)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 2
 
         # restore session
         name = pwd.getpwuid(os.getuid()).pw_name
@@ -202,7 +203,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 1)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 1
 
     def test_json_report(self, tmpdir):
         """
@@ -223,9 +225,11 @@ class TestMain:
         assert excinfo.value.code == libkirk.main.RC_OK
         assert os.path.isfile(report)
 
-        report_a = self.read_report(temp, 2)
+        report_a = self.read_report(temp)
+        assert len(report_a["results"]) == 2
+
         report_b = None
-        with open(report, 'r') as report_f:
+        with open(report, 'r', encoding="utf-8") as report_f:
             report_b = json.loads(report_f.read())
 
         assert report_a == report_b
@@ -247,7 +251,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 1)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 1
 
     def test_skip_file(self, tmpdir):
         """
@@ -269,7 +274,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 1)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 1
 
     def test_skip_tests_and_file(self, tmpdir):
         """
@@ -292,7 +298,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 1)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 1
 
     def test_workers(self, tmpdir):
         """
@@ -312,7 +319,9 @@ class TestMain:
             libkirk.main.run(cmd_args=cmd_args)
 
         assert excinfo.value.code == libkirk.main.RC_OK
-        self.read_report(temp, 2)
+
+        report = self.read_report(temp)
+        assert len(report["results"]) == 2
 
     def test_sut_help(self):
         """
@@ -360,8 +369,9 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        report_d = self.read_report(temp, 1)
-        assert report_d["results"][0]["test"]["log"] == "ciao"
+        report = self.read_report(temp)
+        assert len(report["results"]) == 1
+        assert report["results"][0]["test"]["log"] == "ciao"
 
     def test_suite_iterate(self, tmpdir):
         """
@@ -380,7 +390,8 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        self.read_report(temp, 8)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 8
 
     def test_randomize(self, tmpdir):
         """
@@ -402,10 +413,31 @@ class TestMain:
 
         assert excinfo.value.code == libkirk.main.RC_OK
 
-        report_d = self.read_report(temp, 2 * num_of_suites)
+        report = self.read_report(temp)
+        assert len(report["results"]) == 2 * num_of_suites
 
         tests_names = []
-        for test in report_d["results"]:
+        for test in report["results"]:
             tests_names.append(test["test_fqn"])
 
         assert ["test01", "test02"] * num_of_suites != tests_names
+
+    def test_runtime(self, tmpdir):
+        """
+        Test --runtime option.
+        """
+        temp = tmpdir.mkdir("temp")
+        cmd_args = [
+            "--tmp-dir", str(temp),
+            "--framework", "dummy",
+            "--run-suite", "suite01",
+            "--runtime", "1",
+        ]
+
+        with pytest.raises(SystemExit) as excinfo:
+            libkirk.main.run(cmd_args=cmd_args)
+
+        assert excinfo.value.code == libkirk.main.RC_OK
+
+        report = self.read_report(temp)
+        assert len(report["results"]) > 2

--- a/libkirk/tests/test_session.py
+++ b/libkirk/tests/test_session.py
@@ -163,3 +163,17 @@ class _TestSession:
             tests_names.append(test["test_fqn"])
 
         assert ["test01", "test02"] * num_of_suites != tests_names
+
+    async def test_run_runtime(self, tmpdir, session):
+        """
+        Test run method when executing suites for a certain amount of time.
+        """
+        report = str(tmpdir / "report.json")
+        await session.run(
+            suites=["suite01"],
+            runtime=1,
+            report_path=report)
+
+        with open(report, "r", encoding="utf-8") as report_file:
+            report_data = json.loads(report_file.read())
+            assert len(report_data["results"]) > 2


### PR DESCRIPTION
Add a `--runtime` option that runs kirk session by the given time. If session last longer, it's stopped by the runtime value.
The `30s` syntax is available for this option.