### PR TITLE
ssh: default ~/.ssh/known_hosts as known_hosts

### DIFF
--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -165,6 +165,9 @@ class SSHSUT(SUT):
         self._key_file = kwargs.get("key_file", None)
         self._known_hosts = kwargs.get("known_hosts", "~/.ssh/known_hosts")
 
+        if self._known_hosts == "/dev/null":
+            self._known_hosts = None
+
         try:
             self._port = int(kwargs.get("port", "22"))
 

--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -163,7 +163,7 @@ class SSHSUT(SUT):
         self._user = kwargs.get("user", "root")
         self._password = kwargs.get("password", None)
         self._key_file = kwargs.get("key_file", None)
-        self._known_hosts = kwargs.get("known_hosts", None)
+        self._known_hosts = kwargs.get("known_hosts", "~/.ssh/known_hosts")
 
         try:
             self._port = int(kwargs.get("port", "22"))

--- a/libkirk/ssh.py
+++ b/libkirk/ssh.py
@@ -219,9 +219,9 @@ class SSHSUT(SUT):
 
             self._logger.info("Maximum SSH sessions: %d", max_sessions)
             self._session_sem = asyncio.Semaphore(max_sessions)
-        except asyncssh.misc.ChannelOpenError as err:
+        except asyncssh.misc.Error as err:
             if not self._stop:
-                raise SUTError(err)
+                raise SUTError(err) from err
 
     async def stop(self, iobuffer: IOBuffer = None) -> None:
         if not await self.is_running:
@@ -263,7 +263,7 @@ class SSHSUT(SUT):
         try:
             await self._conn.run("test .", check=True)
         except asyncssh.Error as err:
-            raise SUTError(err)
+            raise SUTError(err) from err
 
         end_t = time.time() - start_t
 
@@ -343,6 +343,6 @@ class SSHSUT(SUT):
             data = ret.stdout
         except asyncssh.Error as err:
             if not self._stop:
-                raise SUTError(err)
+                raise SUTError(err) from err
 
         return data


### PR DESCRIPTION
Change the default ssh known_hosts behavior by using
~/.ssh/known_hosts instead of None. It is the default asyncssh way and
we don't want to be subject of man-in-the-middle attack.

Fixes: https://github.com/linux-test-project/kirk/issues/51
Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>