### PR TITLE
scheduler: show test end message in dmesg

### DIFF
--- a/libkirk/scheduler.py
+++ b/libkirk/scheduler.py
@@ -151,7 +151,7 @@ class TestScheduler(Scheduler):
 
         return code, messages
 
-    async def _write_kmsg(self, test: Test) -> None:
+    async def _write_kmsg(self, test: Test, results: TestResults) -> None:
         """
         If root, we write test information on /dev/kmsg.
         """
@@ -162,10 +162,17 @@ class TestScheduler(Scheduler):
             self._logger.info("Can't write on /dev/kmsg from user")
             return
 
-        message = f'{sys.argv[0]}[{os.getpid()}]: ' \
-            f'starting test {test.name} ({test.full_command})\n'
+        if results:
+            message = f'{sys.argv[0]}[{os.getpid()}]: ' \
+                f'{test.name}: end (returncode: {results.return_code})\n'
 
-        await self._sut.run_command(f'echo -n "{message}" > /dev/kmsg')
+            await self._sut.run_command(f'echo -n "{message}" > /dev/kmsg')
+        else:
+
+            message = f'{sys.argv[0]}[{os.getpid()}]: ' \
+                f'{test.name}: start (command: {test.full_command})\n'
+
+            await self._sut.run_command(f'echo -n "{message}" > /dev/kmsg')
 
     @property
     def results(self) -> list:
@@ -211,7 +218,7 @@ class TestScheduler(Scheduler):
             self._logger.debug(test)
 
             await libkirk.events.fire("test_started", test)
-            await self._write_kmsg(test)
+            await self._write_kmsg(test, None)
 
             iobuffer = RedirectTestStdout(test)
             cmd = test.full_command
@@ -296,6 +303,7 @@ class TestScheduler(Scheduler):
                 raise KernelTimeoutError()
 
             await libkirk.events.fire("test_completed", results)
+            await self._write_kmsg(test, results)
 
             self._logger.info("Test completed: %s", test.name)
             self._logger.debug(results)

--- a/libkirk/tests/test_scheduler.py
+++ b/libkirk/tests/test_scheduler.py
@@ -44,7 +44,7 @@ class MockTestScheduler(TestScheduler):
     and it doesn't write into /dev/kmsg
     """
 
-    async def _write_kmsg(self, test) -> None:
+    async def _write_kmsg(self, test, results) -> None:
         pass
 
 


### PR DESCRIPTION
Provide a message when a test has been completed. The format is:

- "<test>: start (command: <command>)" when test starts
- "<test>: end (returncode: <return code>)" when test ends

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>
Fixes: https://github.com/linux-test-project/kirk/issues/50