### PR TITLE
Respect LTPROOT from environment if set

### DIFF
--- a/libkirk/ltp.py
+++ b/libkirk/ltp.py
@@ -50,7 +50,7 @@ class LTPFramework(Framework):
         }
 
     def setup(self, **kwargs: dict) -> None:
-        self._root = "/opt/ltp"
+        self._root = os.environ.get("LTPROOT", "/opt/ltp")
         self._env = {
             "LTPROOT": self._root,
             "TMPDIR": "/tmp",


### PR DESCRIPTION
Previously, the LTP root directory was hardcoded to `/opt/ltp`. This patch changes the behavior to use the `LTPROOT` environment variable if it is defined, falling back to `/opt/ltp` otherwise.

This allows more flexible test setups without modifying the code.

Reviewed-by: Andrea Cervesato <andrea.cervesato@suse.com>
Reviewed-by: Petr Vorel <pvorel@suse.cz>
Tested-by: Petr Vorel <pvorel@suse.cz>