### PR TITLE
ltp: leave quotes when parsing commands in runtest files

### DIFF
--- a/libkirk/ltp.py
+++ b/libkirk/ltp.py
@@ -42,7 +42,7 @@ class LTPFramework(Framework):
         self._max_runtime = None
         self._tc_folder = None
 
-    @ property
+    @property
     def config_help(self) -> dict:
         return {
             "root": "LTP install folder",
@@ -154,7 +154,9 @@ class LTPFramework(Framework):
 
             self._logger.debug("Test declaration: %s", line)
 
-            parts = shlex.split(line)
+            lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
+
+            parts = list(lexer)
             if len(parts) < 2:
                 raise FrameworkError(
                     "runtest file is not defining test command")


### PR DESCRIPTION
This patch will fix the execution of commands defined in runtest files, if they use single/double quotes in their definition. This is the example of "fs_readonly" that is failing due to double-quotes in their commands definitions.

Fixes: https://github.com/linux-test-project/kirk/issues/60
Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>