### PR TITLE
ltp: don't override LTP_TIMEOUT_MUL if set by user

### DIFF
--- a/libkirk/ltp.py
+++ b/libkirk/ltp.py
@@ -64,7 +64,8 @@ class LTPFramework(Framework):
             self._env.update(env)
 
         timeout = libkirk.types.dict_item(kwargs, "test_timeout", float)
-        if timeout:
+        user_timeout_mul = os.environ.get("LTP_TIMEOUT_MUL")
+        if timeout and not user_timeout_mul:
             self._env["LTP_TIMEOUT_MUL"] = str((timeout * 0.9) / 300.0)
 
         root = libkirk.types.dict_item(kwargs, "root", str)


### PR DESCRIPTION
The Kirk framework was unconditionally calculating and setting the LTP_TIMEOUT_MUL env variable based on the test_timeout parameter, overriding any value that the user might have set beforehand.

This change ensures that if the LTP_TIMEOUT_MUL environment variable is already set in the environment, the framework will not override it. This allows users to explicitly control the timeout multiplier for LTP tests.

The automatic calculation based on test_timeout remains as a fallback when LTP_TIMEOUT_MUL is not set by the user.