### PR TITLE
Make the hvc0 parameter explicit

### DIFF
--- a/doc/users/qemu.rst
+++ b/doc/users/qemu.rst
@@ -15,4 +15,4 @@ To enable console on a tty device for a VM, follow these steps:
 
 .. warning::
 
-    If you set the ``serial=virtio`` backend option, then use ``hvc0`` instead.
+    If you set the ``serial=virtio`` backend option, then use ``console=hvc0`` instead.


### PR DESCRIPTION
While it should be known where hvc0 is to be used, it's better to make the usage explicit so that less experienced users have a chance to understand what this means.