### PR TITLE
scheduler: set CONF status for timed out tests

### DIFF
--- a/libkirk/scheduler.py
+++ b/libkirk/scheduler.py
@@ -24,7 +24,7 @@ from libkirk.errors import (
     SchedulerError,
 )
 from libkirk.framework import Framework
-from libkirk.results import Results, SuiteResults, TestResults
+from libkirk.results import Results, ResultStatus, SuiteResults, TestResults
 from libkirk.sut import SUT, IOBuffer
 
 
@@ -537,6 +537,7 @@ class SuiteScheduler(Scheduler):
                                 exec_time=0.0,
                                 retcode=32,
                                 stdout="",
+                                status=ResultStatus.CONF,
                             )
                         )
 

--- a/libkirk/tests/test_scheduler.py
+++ b/libkirk/tests/test_scheduler.py
@@ -9,6 +9,7 @@ import sys
 import pytest
 
 from libkirk.data import Suite, Test
+from libkirk.results import ResultStatus
 from libkirk.errors import KernelPanicError, KernelTaintedError, KernelTimeoutError
 from libkirk.sut_base import GenericSUT
 from libkirk.channels.shell import ShellComChannel
@@ -518,3 +519,4 @@ class TestSuiteScheduler:
             assert 0 <= res.exec_time < 0.4
             assert res.return_code == 32
             assert res.stdout == ""
+            assert res.status == ResultStatus.CONF


### PR DESCRIPTION
When we stop the scheduler we always set command return code to 32
(skip), but we never set the test results status to CONF. This
patch introduces a fix for it so report file is correctly generated.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>