### PR TITLE
session: implement forcibly stop

### DIFF
--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -460,20 +460,12 @@ def _start_session(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
         exit_code = RC_ERROR
     finally:
         try:
-            # at this point loop has been closed, so we can collect all
-            # tasks and cancel them
-            loop.run_until_complete(
-                # pyrefly: ignore[bad-argument-type]
-                asyncio.gather(
-                    *[
-                        session.stop(),
-                        libkirk.events.stop(),
-                    ]
-                )
-            )
-            libkirk.cancel_tasks(loop)
+            loop.run_until_complete(session.stop())
         except KeyboardInterrupt:
-            pass
+            loop.run_until_complete(session.stop())
+
+        libkirk.cancel_tasks(loop)
+        loop.run_until_complete(libkirk.events.stop())
 
     parser.exit(exit_code)
 

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -375,6 +375,9 @@ class Session:
         """
         Stop the current session.
         """
+        # we don't want to send session_stopped more than once
+        already_stopped = self._stop == True
+
         self._stop = True
         try:
             await self._inner_stop()
@@ -385,7 +388,9 @@ class Session:
             async with self._exec_lock:
                 pass
         finally:
-            await libkirk.events.fire("session_stopped")
+            if not already_stopped:
+                await libkirk.events.fire("session_stopped")
+
             self._stop = False
 
     async def _schedule_once(self, suites_obj: List[Suite]) -> None:


### PR DESCRIPTION
Change the way we complete session by introducing forcibly stop. The
way that kirk works after this patch is the following:
    
- if user sends SIGINT or CTRL+C, we simply wait for the running
  tests to complete and finally stop the session
    
- if user sends SIGINT or CTRL+C again, we stop any execution on the SUT
  and we terminate the testing suite, flagging the killed test as TSKIP
    
Reviewed-by: Cyril Hrubis <chrubis@suse.cz>
Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>
Closes: https://github.com/linux-test-project/kirk/issues/78