### PR TITLE
ssh: ignore decoding errors in utf-8 during connection

### DIFF
--- a/libkirk/channels/ssh.py
+++ b/libkirk/channels/ssh.py
@@ -355,7 +355,10 @@ class SSHComChannel(ComChannel):
 
                 # pyrefly: ignore[missing-attribute]
                 channel, session = await self._conn.create_session(
-                    lambda: MySSHClientSession(iobuffer), cmd
+                    lambda: MySSHClientSession(iobuffer),
+                    cmd,
+                    encoding="utf-8",
+                    errors="ignore",
                 )
 
                 self._channels.append(channel)


### PR DESCRIPTION
Ignore encoding errors with utf-8 during SSH connection. This will fix situations where asyncssh can't start connecting to an SSH server due to the following error:

"Connection failure: 'utf-8' codec can't decode byte 0xYY in position XYZ."

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>