### PR TITLE
sut: add --optimize-sut option

### DIFF
--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -291,6 +291,9 @@ def _get_sut(
     if not sut:
         parser.error(f"'{sut_name}' SUT is not available")
 
+    # pyrefly: ignore[missing-attribute]
+    sut.optimize = args.optimize_sut
+
     try:
         # pyrefly: ignore[missing-attribute]
         sut.setup(**sut_config)
@@ -553,6 +556,12 @@ def run(cmd_args: Optional[List[str]] = None) -> None:
         type=_finjection_config,
         default=0,
         help="Probability of failure (0-100)",
+    )
+    exec_opts.add_argument(
+        "--optimize-sut",
+        "-O",
+        action="store_true",
+        help="Communicate with SUT using commands parallelization (default: false)",
     )
 
     # output arguments


### PR DESCRIPTION
When `--optimize-sut` option is used, kirk will communicate with the SUT using parallel commands execution. This was a feature by deafult, but with the raise of multiple SUT, we need to make it optional in order to ensure that communication with SUT will always work. And the best way to ensure this is to run one command at time, leaving the user to decide when it's time to optimize communication or not.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>