### PR TITLE
ltp: correctly fetch LTPROOT

### DIFF
--- a/libkirk/ltp.py
+++ b/libkirk/ltp.py
@@ -63,7 +63,7 @@ class LTPFramework(Framework):
         self._logger = logging.getLogger("libkirk.ltp")
         self._cmd_matcher = re.compile(r'(?:"[^"]*"|\'[^\']*\'|\S+)')
         self._max_runtime = max_runtime
-        self._root = os.environ.get("LTPROOT", "/opt/ltp")
+        self._root = env.get("LTPROOT") or os.environ.get("LTPROOT", "/opt/ltp")
         self._tc_folder = os.path.join(self._root, "testcases", "bin")
 
         self._env = {
@@ -94,8 +94,7 @@ class LTPFramework(Framework):
             if not ret or ret["returncode"] != 0:
                 raise FrameworkError("Can't read PATH variable")
 
-            tcases = os.path.join(self._root, "testcases", "bin")
-            env["PATH"] = ret["stdout"].strip() + f":{tcases}"
+            env["PATH"] = ret["stdout"].strip() + f":{self._tc_folder}"
 
         self._logger.debug("PATH=%s", env["PATH"])
 

--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -343,7 +343,7 @@ def _start_session(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
     session = Session(
         tmpdir=tmpdir,
         sut=sut,
-        env=args.env,
+        env=args.env or {},
         exec_timeout=args.exec_timeout,
         suite_timeout=args.suite_timeout,
         workers=args.workers,


### PR DESCRIPTION
LTPROOT was previously fetched via --env option, but after the introduction of the new LTPFramework implementation, this feature stopped to work. This patch brings back the correct usage of it.

Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>
Reviewed-by: Li Wang <liwang@redhat.com>