### PR TITLE
Remove --env option

### DIFF
--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -142,20 +142,6 @@ def _print_plugin_help(
     print(msg)
 
 
-def _env_config(value: str) -> Optional[Dict[str, str]]:
-    """
-    Return an environment configuration dictionary, parsing strings such as
-    "key=value:key=value:key=value".
-    """
-    if not value:
-        return None
-
-    params = value.split(":")
-    config = _from_params_to_config(params)
-
-    return config
-
-
 def _iterate_config(value: str) -> int:
     """
     Return the iterate value.
@@ -343,7 +329,6 @@ def _start_session(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
     session = Session(
         tmpdir=tmpdir,
         sut=sut,
-        env=args.env or {},
         exec_timeout=args.exec_timeout,
         suite_timeout=args.suite_timeout,
         workers=args.workers,
@@ -482,12 +467,6 @@ def run(cmd_args: Optional[List[str]] = None) -> None:
         default="default",
         type=lambda x: _dict_config(x),
         help="System Under Test parameters. For help please use '--sut help'",
-    )
-    conf_opts.add_argument(
-        "--env",
-        "-e",
-        type=_env_config,
-        help="List of key=value environment values separated by ':'",
     )
     conf_opts.add_argument("--skip-tests", "-s", type=str, help="Skip specific tests")
     conf_opts.add_argument(

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -62,7 +62,6 @@ class Session:
         self,
         tmpdir: TempDir,
         sut: SUT,
-        env: dict = {},
         exec_timeout: float = 3600.0,
         suite_timeout: float = 3600.0,
         workers: int = 1,
@@ -71,8 +70,6 @@ class Session:
         """
         :param tmpdir: Temporary directory.
         :type tmpdir: TempDir
-        :param env: user environment variables
-        :type env: dict
         :param sut: SUT communication object.
         :type sut: SUT
         :param exec_timeout: Test timeout.
@@ -95,7 +92,6 @@ class Session:
         self._results = []
         self._framework = LTPFramework(
             timeout=self._exec_timeout,
-            env=env,
         )
 
         self._scheduler = SuiteScheduler(

--- a/libkirk/tests/test_main.py
+++ b/libkirk/tests/test_main.py
@@ -358,29 +358,6 @@ class TestMain:
         assert excinfo.value.code == libkirk.main.RC_OK
         assert len(libkirk.sut.get_suts()) > 0
 
-    def test_env(self, tmpdir):
-        """
-        Test --env option.
-        """
-        temp = tmpdir.mkdir("temp")
-        cmd_args = [
-            "--tmp-dir",
-            str(temp),
-            "--run-suite",
-            "environ",
-            "--env",
-            "hello=ciao",
-        ]
-
-        with pytest.raises(SystemExit) as excinfo:
-            libkirk.main.run(cmd_args=cmd_args)
-
-        assert excinfo.value.code == libkirk.main.RC_OK
-
-        report = self.read_report(temp)
-        assert len(report["results"]) == 1
-        assert report["results"][0]["test"]["log"] == "ciao"
-
     def test_suite_iterate(self, tmpdir):
         """
         Test --suite-iterate option.


### PR DESCRIPTION
Remove --env option that was created to support multiple frameworks. Now that we support LTP environment only, we can fetch them directly from the OS environment like it was for `runltp`.

For instance, this will permits to do:

	MYENV1=val1 MYENV2=val2 kirk --run-suite syscalls

instead of:

	kirk --run-suite syscalls --env MYENV1=val1:MYENV2=val2

Closes: https://github.com/linux-test-project/kirk/issues/72
Signed-off-by: Andrea Cervesato <andrea.cervesato@suse.com>
Tested-by: Li Wang <mailto:liwang@redhat.com>
Reviewed-by: Petr Vorel <pvorel@suse.cz>