### PR TITLE
pyproject: include sub-packages in pip package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 version = {attr = "libkirk.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["libkirk"]
+include = ["libkirk", "libkirk.*"]
 exclude = ["libkirk.tests"]
 
 [project.scripts]


### PR DESCRIPTION
The include pattern "libkirk" only match the top-level package so sub-packages like libkirk.channels is missing from the pip package. Add "libkirk.*" to also include sub-packages.

Without this kirk fails with:
  ValueError: Discover folder doesn't exist

Reviewed-by: Andrea Cervesato <andrea.cervesato@suse.com>