### PR TITLE
main: add configurable fault injection interval

### DIFF
--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -199,6 +199,21 @@ def _finjection_config(value: str) -> int:
     return max(0, min(100, ret))
 
 
+def _finterval_config(value: str) -> int:
+    """
+    Return interval of fault injection.
+    """
+    if not value:
+        return 1
+
+    try:
+        ret = int(value)
+    except TypeError as err:
+        raise argparse.ArgumentTypeError("Invalid number") from err
+
+    return max(1, ret)
+
+
 def _get_skip_tests(skip_tests: str, skip_file: str) -> str:
     """
     Return the skipped tests regexp.
@@ -361,6 +376,7 @@ def _start_session(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
                 randomize=args.randomize,
                 runtime=args.runtime,
                 fault_prob=args.fault_injection,
+                fault_interval=args.fault_interval,
             )
         except asyncio.CancelledError:
             await session.stop()
@@ -517,6 +533,12 @@ def run(cmd_args: Optional[List[str]] = None) -> None:
         type=_finjection_config,
         default=0,
         help="Probability of failure (0-100)",
+    )
+    exec_opts.add_argument(
+        "--fault-interval",
+        type=_finterval_config,
+        default=1,
+        help="Fault injection interval (default: 1)",
     )
     exec_opts.add_argument(
         "--optimize-sut",

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -403,7 +403,11 @@ class Session:
         except asyncio.TimeoutError:
             await self._scheduler.stop()
 
-    async def _apply_fault_injection(self, fault_prob: int) -> None:
+    async def _apply_fault_injection(
+        self,
+        fault_prob: int,
+        fault_interval: int = 1,
+    ) -> None:
         """
         Check if we can apply fault injection configuration
         and eventually does it.
@@ -415,7 +419,7 @@ class Session:
                 warn_msg = "Run as root to use kernel fault injection"
         else:
             if await self._sut.is_fault_injection_enabled():
-                await self._sut.setup_fault_injection(fault_prob)
+                await self._sut.setup_fault_injection(fault_prob, fault_interval)
             else:
                 if fault_prob != 0:
                     warn_msg = "Fault injection is not enabled. Running tests normally"
@@ -436,6 +440,7 @@ class Session:
         randomize: bool = False,
         runtime: float = 0,
         fault_prob: int = 0,
+        fault_interval: int = 1,
     ) -> None:
         """
         Run a new session and store results inside a JSON file.
@@ -460,6 +465,8 @@ class Session:
         :type runtime: float
         :param fault_prob: Fault injection probability.
         :type fault_prob: int
+        :param fault_interval: Fault injection interval.
+        :type fault_interval: int
         """
         async with self._run_lock:
             await libkirk.events.fire("session_started", suites, self._tmpdir.abspath)
@@ -477,7 +484,7 @@ class Session:
                     await self._exec_command(command)
 
                 if fault_prob != 0:
-                    await self._apply_fault_injection(fault_prob)
+                    await self._apply_fault_injection(fault_prob, fault_interval)
 
                 if suites:
                     suites_obj = await self._read_suites(

--- a/libkirk/sut.py
+++ b/libkirk/sut.py
@@ -370,18 +370,24 @@ class SUT(Plugin):
 
         return True
 
-    async def setup_fault_injection(self, prob: int) -> None:
+    async def setup_fault_injection(
+        self,
+        prob: int,
+        interval: int = 1,
+    ) -> None:
         """
         Configure kernel fault injection. When prob is zero, the fault
         injection is set to default values.
 
-        :param prob: Fault probabilty in between 0-100.
+        :param prob: Fault probability in between 0-100.
         :type prob: int
+        :param interval: Fault interval.
+        :type interval: int
         """
         if not await self.is_running():
             raise SUTError("SUT is not running")
 
-        interval = 1 if prob == 0 else 100
+        interval = 1 if prob == 0 else interval
         times = 1 if prob == 0 else -1
 
         async def _set_value(value: int, path: str) -> None:

--- a/libkirk/tests/test_main.py
+++ b/libkirk/tests/test_main.py
@@ -110,6 +110,16 @@ class TestHelpers:
 
     def test_finjection_config_negative(self):
         assert libkirk.main._finjection_config("-5") == 0
+    
+    def test_finterval_config_empty(self):
+        assert libkirk.main._finterval_config("") == 1
+
+    def test_finterval_config_negative(self):
+        assert libkirk.main._finterval_config("-5") == 1
+
+    @pytest.mark.parametrize("val", ("1", "20", "100", "2000"))
+    def test_finterval_config(self, val):
+        assert libkirk.main._finterval_config(val) == int(val)
 
     def test_get_skip_tests_empty(self):
         assert libkirk.main._get_skip_tests("", "") == ""


### PR DESCRIPTION
Adds a parameter to configure the fault injection interval, which is locked at default 100.

Can be used to make the fault injection probability checks more frequent. This would lead to a more thorough test of system stability.