### PR TITLE
Add --dry-run option

### DIFF
--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -377,6 +377,7 @@ def _start_session(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
                 runtime=args.runtime,
                 fault_prob=args.fault_injection,
                 fault_interval=args.fault_interval,
+                dry_run=args.dry_run,
             )
         except asyncio.CancelledError:
             await session.stop()
@@ -545,6 +546,12 @@ def run(cmd_args: Optional[List[str]] = None) -> None:
         "-O",
         action="store_true",
         help="Communicate with SUT using commands parallelization (default: false)",
+    )
+    exec_opts.add_argument(
+        "--dry-run",
+        "-D",
+        action="store_true",
+        help="Performs a dry run listing tests (no execution)",
     )
 
     # output arguments

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -441,6 +441,7 @@ class Session:
         runtime: float = 0,
         fault_prob: int = 0,
         fault_interval: int = 1,
+        dry_run: bool = False,
     ) -> None:
         """
         Run a new session and store results inside a JSON file.
@@ -467,6 +468,8 @@ class Session:
         :type fault_prob: int
         :param fault_interval: Fault injection interval.
         :type fault_interval: int
+        :param dry_run: If True, list selected tests without executing them.
+        :type dry_run: bool
         """
         async with self._run_lock:
             await libkirk.events.fire("session_started", suites, self._tmpdir.abspath)
@@ -477,14 +480,20 @@ class Session:
                     "session_warning", "SUT doesn't support parallel execution"
                 )
 
+            if dry_run and command:
+                await libkirk.events.fire("session_dry_run_command", command)
+
             try:
-                await self._start_sut()
+                # SUT is only needed to read suites or to execute tests
+                if suites or not dry_run:
+                    await self._start_sut()
 
-                if command:
-                    await self._exec_command(command)
+                if not dry_run:
+                    if command:
+                        await self._exec_command(command)
 
-                if fault_prob != 0:
-                    await self._apply_fault_injection(fault_prob, fault_interval)
+                    if fault_prob != 0:
+                        await self._apply_fault_injection(fault_prob, fault_interval)
 
                 if suites:
                     suites_obj = await self._read_suites(
@@ -497,7 +506,10 @@ class Session:
                         for suite in suites_obj:
                             random.shuffle(suite.tests)
 
-                    await self._run_scheduler(suites_obj, runtime)
+                    if dry_run:
+                        await libkirk.events.fire("session_dry_run", suites_obj)
+                    else:
+                        await self._run_scheduler(suites_obj, runtime)
             except KirkException as err:
                 if not self._stop:
                     self._logger.exception(err)
@@ -506,7 +518,7 @@ class Session:
             finally:
                 try:
                     # configure fault injection to the original values
-                    if fault_prob != 0:
+                    if fault_prob != 0 and not dry_run:
                         await self._apply_fault_injection(0)
 
                     if self._results:

--- a/libkirk/tests/test_session.py
+++ b/libkirk/tests/test_session.py
@@ -232,6 +232,19 @@ class _TestSession:
         report_data = await self.read_report(report)
         assert len(report_data["results"]) == 4
 
+    async def test_run_dry_run(self, tmpdir, session):
+        """
+        Test run method with dry_run: no tests are executed and no report
+        is generated.
+        """
+        report = str(tmpdir / "report.json")
+        await session.run(
+            suites=["suite01", "suite02"], report_path=report, dry_run=True
+        )
+
+        assert not os.path.exists(report)
+        assert session._results == []
+
     async def test_run_stop(self, session):
         """
         Test stop method during run. We are not going to generate any results

--- a/libkirk/ui.py
+++ b/libkirk/ui.py
@@ -60,6 +60,8 @@ class ConsoleUserInterface:
             "session_warning": self.session_warning,
             "session_error": self.session_error,
             "session_completed": self.session_completed,
+            "session_dry_run": self.session_dry_run,
+            "session_dry_run_command": self.session_dry_run_command,
             "internal_error": self.internal_error,
         }
 
@@ -301,6 +303,36 @@ class ConsoleUserInterface:
             msg = [f"    • {t.test.name}" for t in t_failed]
             await self._print("\n".join(msg))
             await self._print("")
+
+    async def session_dry_run_command(self, command: str) -> None:
+        await self._print("Command:", color=self.CYAN)
+        await self._print(f"    {command}\n")
+
+    async def session_dry_run(self, suites: List[Suite]) -> None:
+        total = 0
+        for suite in suites:
+            parallel = [t.name for t in suite.tests if t.parallelizable]
+            serial = [t.name for t in suite.tests if not t.parallelizable]
+            total += len(suite.tests)
+
+            await self._print_underline(f"Suite: {suite.name}")
+
+            await self._print("Parallel tests:", color=self.CYAN)
+            if parallel:
+                await self._print("\n".join(f"    {n}" for n in parallel))
+            else:
+                await self._print("    (none)")
+
+            await self._print("")
+            await self._print("Serial tests:", color=self.CYAN)
+            if serial:
+                await self._print("\n".join(f"    {n}" for n in serial))
+            else:
+                await self._print("    (none)")
+
+            await self._print("")
+
+        await self._print(f"Total tests: {total} (not executed)")
 
     async def internal_error(self, exc: BaseException, func_name: str) -> None:
         await self._print(


### PR DESCRIPTION
Some developers require to know what tests will be considered before running a kirk session. By adding a --dry-run option, we can achieve this and printing what tests will be executed according to skip/run parameters. The algorithm is:

- download from the SUT runtest files
- apply skip rules to runtest files and extract tests
- print parallel and serial execution tests


Closes: #100