### PR TITLE
session: persist partial results on abort mid-suite

### DIFF
--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -370,8 +370,10 @@ class Session:
         """
         Schedule tests only once.
         """
-        await self._scheduler.schedule(suites_obj)
-        self._results.extend(self._scheduler.results)
+        try:
+            await self._scheduler.schedule(suites_obj)
+        finally:
+            self._results.extend(self._scheduler.results)
 
     async def _schedule_infinite(self, suites_obj: List[Suite]) -> None:
         """

--- a/libkirk/tests/test_session.py
+++ b/libkirk/tests/test_session.py
@@ -13,6 +13,7 @@ import pytest
 from libkirk.ltp import LTPFramework
 from libkirk.com import ComChannel
 from libkirk.data import Test, Suite
+from libkirk.errors import CommunicationError
 from libkirk.results import TestResults
 from libkirk.session import Session
 from libkirk.tempfile import TempDir
@@ -231,6 +232,27 @@ class _TestSession:
 
         report_data = await self.read_report(report)
         assert len(report_data["results"]) == 4
+
+    async def test_run_report_abort(self, tmpdir, session):
+        """
+        Test that results collected before an abort mid-suite are still
+        persisted. The scheduler raises after having run and collected the
+        results, mimicking a SUT connection loss while scheduling.
+        """
+        real_schedule = session._scheduler.schedule
+
+        async def aborting_schedule(jobs):
+            await real_schedule(jobs)
+            raise CommunicationError("SUT connection dropped mid-suite")
+
+        session._scheduler.schedule = aborting_schedule
+
+        report = str(tmpdir / "report.json")
+        with pytest.raises(CommunicationError):
+            await session.run(suites=["suite01"], report_path=report)
+
+        report_data = await self.read_report(report)
+        assert len(report_data["results"]) == 2
 
     async def test_run_dry_run(self, tmpdir, session):
         """


### PR DESCRIPTION
self._results is only extended after _scheduler.schedule() returns. When
a KirkException is raised during scheduling (e.g. a CommunicationError on
SUT connection loss), the extend is skipped and self._results stays empty,
even though the scheduler already collected results for the tests that ran.
The export guard then skips writing results.json, discarding those results.

Wrap the extend in _schedule_once() with try/finally so results collected
before the abort are carried over and exported. Add a regression test in
_TestSession so it runs against every SUT implementation.

Closes #102