### PR TITLE
Add instructions for uv

### DIFF
--- a/doc/users/quickstart.rst
+++ b/doc/users/quickstart.rst
@@ -22,11 +22,15 @@ To use kirk via git repository:
     kirk --help
 
 kirk is also present in `pypi <https://pypi.org/project/kirk>`_ and it can be
-installed via ``pip`` command:
+installed via ``pip`` or ``uv``:
 
 .. code-block:: bash
 
    pip install --user kirk
+
+   uvx --with kirk kirk
+   # with optional dependencies:
+   uvx --with kirk[ssh,ltx] kirk
 
 Some basic commands are the following:
 


### PR DESCRIPTION
Add instructions on how to install kirk using the `uv` package manager for Python including using the optional requirements. This should allow users to quickly get running with kirk using uv without looking into the pyproject.toml file for dependency discovery.