### PR TITLE
json2logs: fix warn status treated as failure and sanitize FQN filename

### DIFF
--- a/utils/json2logs.py
+++ b/utils/json2logs.py
@@ -43,9 +43,10 @@ def process_kirk_results(resfile, sumfile, runfile, failfile):
 
         run_logs.append(test_log)
 
-        if status not in ("pass", "conf"):
+        if status in ("fail", "brok"):
             fail_logs.append(test_log)
-            with open(f"{fqn}.fail.log", "w") as f:
+            safe_fqn = fqn.replace("/", "_")
+            with open(f"{safe_fqn}.fail.log", "w") as f:
                 f.write(test_log)
 
     env = data.get("environment", {})


### PR DESCRIPTION
  The condition `status not in ("pass", "conf")` treated warn tests as
  failures, writing them to fails.log and generating .fail.log files.
  Changed to `status in ("fail", "brok")` so only actual failures and
  broken tests are reported.

  Also replace "/" in test FQN before using it as a filename to avoid
  creating unintended subdirectories.

  Signed-off-by: Michael Menasherov <mmenashe@redhat.com>