### PR TITLE
main: add --shard option for test sharding

### DIFF
--- a/doc/users/quickstart.rst
+++ b/doc/users/quickstart.rst
@@ -56,6 +56,12 @@ Run a custom command before executing the test suite:
     kirk --run-command ./setup_sut.sh \
          --run-suite syscalls
 
+Run a subset of tests using sharding (e.g., shard 1 of 4):
+
+.. code-block:: bash
+
+    kirk --run-suite syscalls --shard 1/4
+
 Optional features
 -----------------
 

--- a/libkirk/main.py
+++ b/libkirk/main.py
@@ -14,6 +14,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -214,6 +215,29 @@ def _finterval_config(value: str) -> int:
     return max(1, ret)
 
 
+def _shard_config(value: str) -> Tuple[int, int]:
+    """
+    Return shard configuration as (index, total).
+    """
+    match = re.fullmatch(
+        r"(?P<index>[0-9]{1,9})\s*/\s*(?P<total>[0-9]{1,9})", value.strip()
+    )
+    if not match:
+        raise argparse.ArgumentTypeError(
+            f"Invalid shard format '{value}'. Expected <index>/<total> (e.g., 1/4)"
+        )
+
+    index = int(match.group("index"))
+    total = int(match.group("total"))
+
+    if not 1 <= index <= total:
+        raise argparse.ArgumentTypeError(
+            f"Incorrect shard '{value}', expected 1 <= index <= total"
+        )
+
+    return (index, total)
+
+
 def _get_skip_tests(skip_tests: str, skip_file: str) -> str:
     """
     Return the skipped tests regexp.
@@ -378,6 +402,7 @@ def _start_session(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
                 fault_prob=args.fault_injection,
                 fault_interval=args.fault_interval,
                 dry_run=args.dry_run,
+                shard=args.shard,
             )
         except asyncio.CancelledError:
             await session.stop()
@@ -552,6 +577,12 @@ def run(cmd_args: Optional[List[str]] = None) -> None:
         "-D",
         action="store_true",
         help="Performs a dry run listing tests (no execution)",
+    )
+    exec_opts.add_argument(
+        "--shard",
+        type=_shard_config,
+        default=None,
+        help="Run only a subset of tests: <index>/<total> (e.g., 1/4)",
     )
 
     # output arguments

--- a/libkirk/session.py
+++ b/libkirk/session.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 
 import libkirk
@@ -272,22 +273,45 @@ class Session:
 
         return suites_list
 
+    @staticmethod
+    def _apply_sharding(
+        suites_obj: List[Suite], shard: Optional[Tuple[int, int]] = None
+    ) -> None:
+        """
+        Distribute tests across shards using round-robin.
+        """
+        if not shard:
+            return
+
+        index, count = shard
+        for suite_obj in suites_obj:
+            suite_obj.tests[:] = [
+                test
+                for i, test in enumerate(suite_obj.tests)
+                if i % count == (index - 1)
+            ]
+
     async def _read_suites(
         self,
         names: List[str],
         pattern: Optional[str] = None,
         skip_tests: Optional[str] = None,
         restore_path: Optional[str] = None,
+        shard: Optional[Tuple[int, int]] = None,
     ) -> List[Suite]:
         """
         Read suites and return a list of Suite objects.
         """
         suites_obj = await self._get_suites_objects(names)
 
-        await self._restore_tests(suites_obj, restore_path)
-
         self._filter_tests(suites_obj, pattern, False)
         self._filter_tests(suites_obj, skip_tests, True)
+        self._apply_sharding(suites_obj, shard)
+
+        await self._restore_tests(suites_obj, restore_path)
+
+        # Prune suites that have no tests left after filtering and sharding
+        suites_obj[:] = [suite for suite in suites_obj if len(suite.tests) > 0]
 
         num_tests = sum(len(suite_obj.tests) for suite_obj in suites_obj)
         if num_tests == 0:
@@ -444,6 +468,7 @@ class Session:
         fault_prob: int = 0,
         fault_interval: int = 1,
         dry_run: bool = False,
+        shard: Optional[Tuple[int, int]] = None,
     ) -> None:
         """
         Run a new session and store results inside a JSON file.
@@ -472,6 +497,8 @@ class Session:
         :type fault_interval: int
         :param dry_run: If True, list selected tests without executing them.
         :type dry_run: bool
+        :param shard: Shard tuple (index, total) to run a subset of tests.
+        :type shard: tuple(int, int) | None
         """
         async with self._run_lock:
             await libkirk.events.fire("session_started", suites, self._tmpdir.abspath)
@@ -499,7 +526,7 @@ class Session:
 
                 if suites:
                     suites_obj = await self._read_suites(
-                        suites, pattern, skip_tests, restore_path
+                        suites, pattern, skip_tests, restore_path, shard
                     )
 
                     suites_obj = self._apply_iterate(suites_obj, suite_iterate)

--- a/libkirk/tests/test_main.py
+++ b/libkirk/tests/test_main.py
@@ -121,6 +121,33 @@ class TestHelpers:
     def test_finterval_config(self, val):
         assert libkirk.main._finterval_config(val) == int(val)
 
+    @pytest.mark.parametrize(
+        "val,expected",
+        [
+            ("1/4", (1, 4)),
+            ("3/3", (3, 3)),
+            (" 2 / 5 ", (2, 5)),
+            ("  1   /   10  ", (1, 10)),
+            ("\t4 / 8\n", (4, 8)),
+        ],
+    )
+    def test_shard_config_valid(self, val, expected):
+        assert libkirk.main._shard_config(val) == expected
+
+    def test_shard_config_empty(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            libkirk.main._shard_config("")
+
+    @pytest.mark.parametrize("val", ("1", "1-4", "abc", "1/2/3", "1/", " ", "  \t  "))
+    def test_shard_config_invalid_format(self, val):
+        with pytest.raises(argparse.ArgumentTypeError):
+            libkirk.main._shard_config(val)
+
+    @pytest.mark.parametrize("val", ("0/4", "5/4", "1/0", "0/0"))
+    def test_shard_config_out_of_bounds(self, val):
+        with pytest.raises(argparse.ArgumentTypeError):
+            libkirk.main._shard_config(val)
+
     def test_get_skip_tests_empty(self):
         assert libkirk.main._get_skip_tests("", "") == ""
 
@@ -708,3 +735,44 @@ class TestMain:
 
         names = [com.name for com in libkirk.com.get_channels()]
         assert "myshell" in names
+
+    def test_shard(self, tmpdir):
+        """
+        Test --shard option.
+        """
+        temp1 = tmpdir.mkdir("temp1")
+        cmd_args1 = [
+            "--tmp-dir",
+            str(temp1),
+            "--run-suite",
+            "suite01",
+            "--shard",
+            "1/2",
+        ]
+
+        with pytest.raises(SystemExit) as excinfo:
+            libkirk.main.run(cmd_args=cmd_args1)
+
+        assert excinfo.value.code == libkirk.main.RC_OK
+
+        report1 = self.read_report(temp1)
+        assert len(report1["results"]) == 1
+
+        temp2 = tmpdir.mkdir("temp2")
+        cmd_args2 = [
+            "--tmp-dir",
+            str(temp2),
+            "--run-suite",
+            "suite01",
+            "--shard",
+            "2/2",
+        ]
+
+        with pytest.raises(SystemExit) as excinfo:
+            libkirk.main.run(cmd_args=cmd_args2)
+
+        assert excinfo.value.code == libkirk.main.RC_OK
+
+        report2 = self.read_report(temp2)
+        assert len(report2["results"]) == 1
+        assert report1["results"][0]["test_fqn"] != report2["results"][0]["test_fqn"]

--- a/libkirk/tests/test_session.py
+++ b/libkirk/tests/test_session.py
@@ -382,3 +382,76 @@ class _TestSession:
 
         report_data = await self.read_report(report)
         assert len(report_data["results"]) >= 0.5
+
+    def test_apply_sharding(self):
+        """
+        Test Session._apply_sharding round-robin algorithm.
+        """
+        tests = [Test(name=f"test{i}", cmd="echo") for i in range(10)]
+
+        s1 = [Suite("mysuite", list(tests))]
+        Session._apply_sharding(s1, (1, 3))
+        assert [t.name for t in s1[0].tests] == ["test0", "test3", "test6", "test9"]
+
+        s2 = [Suite("mysuite", list(tests))]
+        Session._apply_sharding(s2, (2, 3))
+        assert [t.name for t in s2[0].tests] == ["test1", "test4", "test7"]
+
+        s3 = [Suite("mysuite", list(tests))]
+        Session._apply_sharding(s3, (3, 3))
+        assert [t.name for t in s3[0].tests] == ["test2", "test5", "test8"]
+
+        # None shard should not modify tests
+        s_none = [Suite("mysuite", list(tests))]
+        Session._apply_sharding(s_none, None)
+        assert len(s_none[0].tests) == 10
+
+    @pytest.mark.parametrize(
+        "shard,expected_test",
+        [
+            ((1, 2), "test01"),
+            ((2, 2), "test02"),
+        ],
+    )
+    async def test_run_shard(self, tmpdir, session, shard, expected_test):
+        """
+        Test run method with sharding.
+        """
+        report = str(tmpdir / "report.json")
+        await session.run(suites=["suite01"], shard=shard, report_path=report)
+        data = await self.read_report(report)
+        assert len(data["results"]) == 1
+        assert data["results"][0]["test_fqn"] == expected_test
+
+    async def test_run_shard_multiple_suites(self, tmpdir, session):
+        """
+        Test sharding across multiple suites with empty suite pruning.
+        """
+        report = str(tmpdir / "report.json")
+        await session.run(
+            suites=["suite01", "suite02"], shard=(1, 2), report_path=report
+        )
+        data = await self.read_report(report)
+        assert len(data["results"]) == 2
+
+    async def test_run_shard_with_restore(self, tmpdir, session):
+        """
+        Test that sharding happens before restore so test partitioning remains stable.
+        """
+        # Simulate previous execution where suite01::test01 was already executed
+        executed_file = tmpdir / "executed"
+        executed_file.write("suite01::test01\n")
+
+        # Shard (1, 2) should pick test01 (and test03, etc.).
+        # Since test01 is already in executed, shard (1, 2) has nothing left in suite01.
+        # But shard (2, 2) which owns test02 should still run test02 and not be shifted.
+        report = str(tmpdir / "report.json")
+        await session.run(
+            suites=["suite01"],
+            shard=(2, 2),
+            restore_path=str(tmpdir),
+            report_path=report,
+        )
+        data = await self.read_report(report)
+        assert len(data["results"]) == 1
+        assert data["results"][0]["test_fqn"] == "test02"


### PR DESCRIPTION
Add the --shard <index>/<total> option to distribute testing suites across multiple machines using round-robin test partitioning.

Closes: https://github.com/linux-test-project/kirk/issues/48